### PR TITLE
cleanup using cppcheck (I tested, it builds successfully)

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -139,23 +139,6 @@ tapPacketRemoveHeadLocked(
     return tapPacket;
 }
 
-PTAP_PACKET
-tapPacketRemoveHead(
-    __in PTAP_PACKET_QUEUE  TapPacketQueue
-    )
-{
-    PTAP_PACKET     tapPacket = NULL;
-    KIRQL           irql;
-
-    KeAcquireSpinLock(&TapPacketQueue->QueueLock,&irql);
-
-    tapPacket = tapPacketRemoveHeadLocked(TapPacketQueue);
-
-    KeReleaseSpinLock(&TapPacketQueue->QueueLock,irql);
-
-    return tapPacket;
-}
-
 VOID
 tapPacketQueueInitialize(
     __in PTAP_PACKET_QUEUE  TapPacketQueue

--- a/src/mem.h
+++ b/src/mem.h
@@ -79,11 +79,6 @@ tapPacketRemoveHeadLocked(
     __in PTAP_PACKET_QUEUE  TapPacketQueue
     );
 
-PTAP_PACKET
-tapPacketRemoveHead(
-    __in PTAP_PACKET_QUEUE  TapPacketQueue
-    );
-
 VOID
 tapPacketQueueInitialize(
     __in PTAP_PACKET_QUEUE  TapPacketQueue

--- a/src/txpath.c
+++ b/src/txpath.c
@@ -98,7 +98,6 @@ HandleIPv6NeighborDiscovery(
     __in UCHAR * m_Data
     )
 {
-    const ETH_HEADER * e = (ETH_HEADER *) m_Data;
     const IPV6HDR *ipv6 = (IPV6HDR *) (m_Data + sizeof (ETH_HEADER));
     const ICMPV6_NS * icmpv6_ns = (ICMPV6_NS *) (m_Data + sizeof (ETH_HEADER) + sizeof (IPV6HDR));
     ICMPV6_NA_PKT *na;
@@ -696,7 +695,6 @@ no_queue:
         NdisFreeMemory(tapPacket,0,0);
     }
   
-exit_success:
     return;
 }
 


### PR DESCRIPTION
[txpath.c:699]: (style) Label 'exit_success' is not used.
[txpath.c:101]: (style) Variable 'e' is assigned a value that is never used.
[mem.c:143]: (style) The function 'tapPacketRemoveHead' is never used.