### PR TITLE
Fix linefeeds in license.txt

### DIFF
--- a/buildtap.py
+++ b/buildtap.py
@@ -311,9 +311,7 @@ class BuildTAPWindows(object):
 
         for f in (os.path.join(self.top, 'COPYING'), os.path.join(self.top, 'COPYRIGHT.GPL')):
             src=open(f, mode='rb')
-            input = src.read()
-            output = input.replace('\n', '\r\n')
-            dst.write(output+' \n')
+            dst.write(src.read()+'\r\n')
             src.close()
 
         dst.close()


### PR DESCRIPTION
Typically Git on Windows is configured to check out files with CRLF
linefeeds. This meant that the extra linefeed conversion step in
buildtap.py was not only unnecessary, but also harmful. The symptom was
that the NSI installer showed the whole license.txt on a single line.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>