### PR TITLE
Allow getting code-signing certificate from the machine store

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,25 +25,32 @@ Windows 2012 Server using Git Bash and Windows Powershell.
 
 View build script options::
 
-  $ python buildtap.py
-  Usage: buildtap.py [options]
+    $ python buildtap.py
+    Usage: buildtap.py [options]
 
-  Options:
-    -h, --help         show this help message and exit
-    -s SRC, --src=SRC  TAP-Windows top-level directory, default=<CWD>
-    --ti=TAPINSTALL    tapinstall (i.e. devcon) directory (optional)
-    -d, --debug        enable debug build
-    -c, --clean        do an nmake clean before build
-    -b, --build        build TAP-Windows and possibly tapinstall (add -c to
-                       clean before build)
-    --sign         sign the driver files (disabled by default)
-    -p, --package      generate an NSIS installer from the compiled files
-    --cert=CERT        Common name of code signing certificate, default=openvpn
-    --crosscert=CERT   The cross-certificate file to use, default=MSCV-
-                       VSClass3.cer
-    --timestamp=URL    Timestamp URL to use, default=http://timestamp.verisign.c
-                       om/scripts/timstamp.dll
-    -a, --oas          Build for OpenVPN Access Server clients
+    Options:
+      -h, --help           show this help message and exit
+      -s SRC, --src=SRC    TAP-Windows top-level directory,
+                           default=C:\Users\samuli\opt\tap-windows6
+      --ti=TAPINSTALL      tapinstall (i.e. devcon) directory (optional)
+      -d, --debug          enable debug build
+      -c, --clean          do an nmake clean before build
+      -b, --build          build TAP-Windows and possibly tapinstall (add -c to
+                           clean before build)
+      --sign               sign the driver files
+      -p, --package        generate an NSIS installer from the compiled files
+      --cert=CERT          Common name of code signing certificate,
+                           default=openvpn
+      --machinestore       load certificate from machine store instead of user
+                           store
+      --certfile=CERTFILE  Path to the code signing certificate
+      --certpw=CERTPW      Password for the code signing certificate/key
+                           (optional)
+      --crosscert=CERT     The cross-certificate file to use, default=MSCV-
+                           VSClass3.cer
+      --timestamp=URL      Timestamp URL to use, default=http://timestamp.verisign
+                           .com/scripts/timstamp.dll
+      -a, --oas            Build for OpenVPN Access Server clients
 
 Edit **version.m4** and **paths.py** as necessary then build::
 

--- a/buildtap.py
+++ b/buildtap.py
@@ -30,6 +30,7 @@ class BuildTAPWindows(object):
         # driver signing options
         self.codesign = opt.codesign
         self.sign_cn = opt.cert
+        self.machinestore = opt.machinestore
         self.sign_cert = opt.certfile
         self.cert_pw = opt.certpw
         self.crosscert = os.path.join(self.top, opt.crosscert)
@@ -425,6 +426,8 @@ class BuildTAPWindows(object):
                 certspec += "/p '%s' " % self.cert_pw
         else:
             certspec += "/s my /n '%s' " % self.sign_cn
+            if self.machinestore:
+                certspec += "/sm "
 
         self.system("%s sign /v /ac %s %s /t %s %s" % (
                 self.signtool_cmd,
@@ -486,6 +489,8 @@ if __name__ == '__main__':
     op.add_option("--cert", dest="cert", metavar="CERT",
                   default=cert,
                   help="Common name of code signing certificate, default=%s" % (cert,))
+    op.add_option("--machinestore", action="store_true", dest="machinestore",
+                  help="load certificate from machine store instead of user store")
     op.add_option("--certfile", dest="certfile", metavar="CERTFILE",
                   help="Path to the code signing certificate")
     op.add_option("--certpw", dest="certpw", metavar="CERTPW",


### PR DESCRIPTION
This can be useful if one needs to use two code-signing certificates
that have identical names, or if the machine store is the preferred
location.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>