### PR TITLE
NDIS 6.30 upgrade

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,10 @@
 TAP-Windows driver (NDIS 6)
 ===========================
 
-This is an NDIS 6.20 implementation of the TAP-Windows driver, used by
-OpenVPN and other apps. NDIS 6.20 drivers can run on Windows 7 or higher.
+This is an NDIS 6.20/6.30 implementation of the TAP-Windows driver, used by
+OpenVPN and other apps. NDIS 6.20 drivers can run on Windows 7 or higher except
+on ARM64 desktop systems where, since the platform relies on next-gen power
+management in its drivers, NDIS 6.30 is required.
 
 Build
 -----

--- a/README.rst
+++ b/README.rst
@@ -70,10 +70,17 @@ by using the --sign parameter.
 Building tapinstall (optional)
 ------------------------------
 
-The build system supports building tapinstall.exe (a.k.a. devcon.exe), but the
-default behavior is to reuse pre-built executables. To make sure the buildsystem
-finds the executables create the following directory structure under
-tap-windows6 directory:
+The easiest way to build tapinstall is to clone the Microsoft driver samples
+and copy the source for devcon.exe into the tap-windows6 tree. Using PowerShell:
+
+    git clone https://github.com/Microsoft/Windows-driver-samples
+    Copy-Item -Recurse Windows-driver-samples/setup/devcon tap-windows6
+    cd tap-windows6
+    python.exe buildtap.py -b --ti=devcon
+
+The build system also supports reuse of pre-built executables. To make sure the
+buildsystem finds the executables, create the following directory structure
+under tap-windows6 directory:
 ::
   tapinstall
   ├── Release

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -655,14 +655,25 @@ AdapterCreate(
         //
         // Set the registration attributes.
         //
-        {C_ASSERT(sizeof(regAttributes) >= NDIS_SIZEOF_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES_REVISION_1);}
+
+        {C_ASSERT(sizeof(regAttributes) >= NDIS_SIZEOF_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES_REVISION_2);}
+
         regAttributes.Header.Type = NDIS_OBJECT_TYPE_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES;
-        regAttributes.Header.Size = NDIS_SIZEOF_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES_REVISION_1;
-        regAttributes.Header.Revision = NDIS_SIZEOF_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES_REVISION_1;
+
+        if (GlobalData.NdisVersion < NDIS_RUNTIME_VERSION_630)
+        {
+            regAttributes.Header.Size = NDIS_SIZEOF_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES_REVISION_1;
+            regAttributes.Header.Revision = NDIS_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES_REVISION_1;
+        }
+        else
+        {
+            regAttributes.Header.Size = NDIS_SIZEOF_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES_REVISION_2;
+            regAttributes.Header.Revision = NDIS_MINIPORT_ADAPTER_REGISTRATION_ATTRIBUTES_REVISION_2;
+        }
 
         regAttributes.MiniportAdapterContext = adapter;
-        regAttributes.AttributeFlags = TAP_ADAPTER_ATTRIBUTES_FLAGS;
 
+        regAttributes.AttributeFlags = TAP_ADAPTER_ATTRIBUTES_FLAGS;
         regAttributes.CheckForHangTimeInSeconds = TAP_ADAPTER_CHECK_FOR_HANG_TIME_IN_SECONDS;
         regAttributes.InterfaceType = TAP_INTERFACE_TYPE;
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -38,21 +38,9 @@
 //
 // Define the NDIS miniport interface version that this driver targets.
 //
-#if defined(NDIS60_MINIPORT)
-#  define TAP_NDIS_MAJOR_VERSION    6
-#  define TAP_NDIS_MINOR_VERSION    0
-#elif defined(NDIS61_MINIPORT)
-#  define TAP_NDIS_MAJOR_VERSION    6
-#  define TAP_NDIS_MINOR_VERSION    1
-#elif defined(NDIS620_MINIPORT)
-#  define TAP_NDIS_MAJOR_VERSION    6
-#  define TAP_NDIS_MINOR_VERSION    20
-#elif defined(NDIS630_MINIPORT)
-#  define TAP_NDIS_MAJOR_VERSION    6
-#  define TAP_NDIS_MINOR_VERSION    30
-#else
-#define TAP_NDIS_MAJOR_VERSION      5
-#define TAP_NDIS_MINOR_VERSION      0
+
+#if !defined(NDIS620_MINIPORT)
+#error "tap-windows6 only supports NDIS 6.20 at this time"
 #endif
 
 //===========================================================

--- a/src/constants.h
+++ b/src/constants.h
@@ -39,8 +39,8 @@
 // Define the NDIS miniport interface version that this driver targets.
 //
 
-#if !defined(NDIS620_MINIPORT)
-#error "tap-windows6 only supports NDIS 6.20 at this time"
+#if !defined(NDIS620_MINIPORT) || !defined(NDIS630_MINIPORT)
+#error "tap-windows6 only supports NDIS 6.20 and 6.30 at this time"
 #endif
 
 //===========================================================

--- a/src/tap-windows6.vcxproj.in
+++ b/src/tap-windows6.vcxproj.in
@@ -116,7 +116,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DisableSpecificWarnings>%(DisableSpecificWarnings);4201;4214;4100;4101;4200</DisableSpecificWarnings>
       <TreatWarningAsError>false</TreatWarningAsError>
-      <PreprocessorDefinitions>%(PreprocessorDefinitions);TAP_DRIVER_MAJOR_VERSION=@PRODUCT_TAP_WIN_MAJOR@;TAP_DRIVER_MINOR_VERSION=@PRODUCT_TAP_WIN_MINOR@;NDIS_WDM=1;NDIS_MINIPORT_DRIVER=1;NDIS620_MINIPORT=1</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);TAP_DRIVER_MAJOR_VERSION=@PRODUCT_TAP_WIN_MAJOR@;TAP_DRIVER_MINOR_VERSION=@PRODUCT_TAP_WIN_MINOR@;NDIS_WDM=1;NDIS_MINIPORT_DRIVER=1;NDIS620_MINIPORT=1;NDIS630_MINIPORT=1</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>%(AdditionalDependencies);$(KernelBufferOverflowLib);$(DDK_LIB_PATH)ntoskrnl.lib;$(DDK_LIB_PATH)hal.lib;$(DDK_LIB_PATH)wmilib.lib;ndis.lib;ntstrsafe.lib;wdmsec.lib</AdditionalDependencies>

--- a/src/tap-windows6.vcxproj.in
+++ b/src/tap-windows6.vcxproj.in
@@ -114,7 +114,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>
-      <DisableSpecificWarnings>%(DisableSpecificWarnings);4201;4214;4100;4101;4200</DisableSpecificWarnings>
+      <DisableSpecificWarnings>%(DisableSpecificWarnings);4201;4214;4100;4101;4200;4057;4127</DisableSpecificWarnings>
       <TreatWarningAsError>false</TreatWarningAsError>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);TAP_DRIVER_MAJOR_VERSION=@PRODUCT_TAP_WIN_MAJOR@;TAP_DRIVER_MINOR_VERSION=@PRODUCT_TAP_WIN_MINOR@;NDIS_WDM=1;NDIS_MINIPORT_DRIVER=1;NDIS620_MINIPORT=1;NDIS630_MINIPORT=1</PreprocessorDefinitions>
     </ClCompile>

--- a/src/tap.h
+++ b/src/tap.h
@@ -74,10 +74,15 @@ typedef struct _TAP_GLOBAL
 
     NDIS_HANDLE         NdisDriverHandle;   // From NdisMRegisterMiniportDriver
 
+    UINT NdisVersion;
+
 } TAP_GLOBAL, *PTAP_GLOBAL;
 
 
 // Global data
 extern TAP_GLOBAL      GlobalData;
+
+#define TAP_NDIS_MAJOR_VERSION ((UCHAR)(GlobalData.NdisVersion >> 16))
+#define TAP_NDIS_MINOR_VERSION ((UCHAR)(GlobalData.NdisVersion & 0xFF))
 
 #endif // __TAP_H

--- a/src/tapdrvr.c
+++ b/src/tapdrvr.c
@@ -94,7 +94,24 @@ Arguments:
     NdisZeroMemory(&GlobalData, sizeof(GlobalData));
 
     //
-    // The ApaterList in the GlobalData structure is used to track multiple
+    // Check what NDIS version is supported by the OS
+    //
+    GlobalData.NdisVersion = NdisGetVersion();
+    if (GlobalData.NdisVersion < NDIS_RUNTIME_VERSION_620)
+    {
+        return NDIS_STATUS_UNSUPPORTED_REVISION;
+    }
+    if (GlobalData.NdisVersion == NDIS_RUNTIME_VERSION_620)
+    {
+        GlobalData.NdisVersion = NDIS_RUNTIME_VERSION_620;
+    }
+    if (GlobalData.NdisVersion > NDIS_RUNTIME_VERSION_620)
+    {
+        GlobalData.NdisVersion = NDIS_RUNTIME_VERSION_620;
+    }
+
+    //
+    // The AdapterList in the GlobalData structure is used to track multiple
     // adapters controlled by this miniport.
     //
     NdisInitializeListHead(&GlobalData.AdapterList);

--- a/src/tapdrvr.c
+++ b/src/tapdrvr.c
@@ -107,7 +107,7 @@ Arguments:
     }
     if (GlobalData.NdisVersion > NDIS_RUNTIME_VERSION_620)
     {
-        GlobalData.NdisVersion = NDIS_RUNTIME_VERSION_620;
+        GlobalData.NdisVersion = NDIS_RUNTIME_VERSION_630;
     }
 
     //


### PR DESCRIPTION
Using MSDN guidance, this is a naïve upgrade of the driver to NDIS 6.30. This is required for compatibility with Windows 10 on ARM.

Since 6.20 is required for compatibility Windows 7, 6.30 support is conditional at runtime.