### PR TITLE
Throw exception when any buildtap.py system command fails

### DIFF
--- a/buildtap.py
+++ b/buildtap.py
@@ -72,7 +72,9 @@ class BuildTAPWindows(object):
     # run a command
     def system(self, cmd):
         print "RUN:", cmd
-        os.system(cmd)
+        result = os.system(cmd)
+        if result != 0:
+            raise ValueError("command failed")
 
     # make a directory
     def mkdir(self, dir):


### PR DESCRIPTION
Silently ignoring non-zero error levels returned by various build
commands makes build process continue on error. In some scenarios build
process does not detect missing or invalid command outputs and continues
to produce an invalid result giving a false sense of success.