### PR TITLE
Mark RX MDL as no-execute for HVCI compliance

### DIFF
--- a/src/tap.h
+++ b/src/tap.h
@@ -74,6 +74,8 @@ typedef struct _TAP_GLOBAL
 
     NDIS_HANDLE         NdisDriverHandle;   // From NdisMRegisterMiniportDriver
 
+    BOOLEAN             RunningWindows8OrGreater;
+
 } TAP_GLOBAL, *PTAP_GLOBAL;
 
 


### PR DESCRIPTION
Prior to Windows 8, when a driver created an MDL to dual-map a user page into kernel space the MDL was RWX by default. On Windows 8 and above, a pair of new flags were added that create the MDL as either RW or RX. Using these flags appropriately fills the requirement of Windows' HyperVisor-enforced Code Integrity mechanism that no kernel-mode pages are ever both writeable and executable. 

This change adds a runtime OS version check to driver initialization and uses it to conditionally add the `MdlMappingNoExecute` flag to the driver's calls to `MmGetSystemAddressForMdlSafe`.