### PR TITLE
Reestablish AppVeyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,4 +3,4 @@ image: Visual Studio 2015
 build_script:
 - cmd: python buildtap.py -b --sdk=wdk
 artifacts:
-- path: '*'
+- path: 'tap6.tar.gz'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,6 @@
 version: 1.0.{build}
+image: Visual Studio 2015
 build_script:
-- cmd: python buildtap.py -b
+- cmd: python buildtap.py -b --sdk=wdk
 artifacts:
 - path: '*'

--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,8 @@ To build, the following prerequisites are required:
 
 - Python 2.7
 - Microsoft Windows 10 EWDK (Enterprise Windows Driver Kit)
-    - WDK works too, but
-        - the tool paths are all different
-        - the environment script is the one for the Developer Command Prompt for VS 2017
+    - Visual Studio+Windows Driver Kit works too. Make sure to work from a
+      "Command Prompt for Visual Studio" and to call buildtap.py with "--sdk=wdk".
 - Source code directory of **devcon** sample from WDK (optional)
     - https://github.com/Microsoft/Windows-driver-samples/ setup/devcon
 - Windows code signing certificate
@@ -30,23 +29,28 @@ View build script options::
 
   $ python buildtap.py
   Usage: buildtap.py [options]
-
+  
   Options:
-    -h, --help         show this help message and exit
-    -s SRC, --src=SRC  TAP-Windows top-level directory, default=<CWD>
-    --ti=TAPINSTALL    tapinstall (i.e. devcon) directory (optional)
-    -d, --debug        enable debug build
-    -c, --clean        do an nmake clean before build
-    -b, --build        build TAP-Windows and possibly tapinstall (add -c to
-                       clean before build)
-    --sign         sign the driver files (disabled by default)
-    -p, --package      generate an NSIS installer from the compiled files
-    --cert=CERT        Common name of code signing certificate, default=openvpn
-    --crosscert=CERT   The cross-certificate file to use, default=MSCV-
-                       VSClass3.cer
-    --timestamp=URL    Timestamp URL to use, default=http://timestamp.verisign.c
-                       om/scripts/timstamp.dll
-    -a, --oas          Build for OpenVPN Access Server clients
+    -h, --help           show this help message and exit
+    -s SRC, --src=SRC    TAP-Windows top-level directory, default=<CWD>
+    --ti=TAPINSTALL      tapinstall (i.e. devcon) directory (optional)
+    -d, --debug          enable debug build
+    -c, --clean          do an nmake clean before build
+    -b, --build          build TAP-Windows and possibly tapinstall (add -c to
+                         clean before build)
+    --sdk=SDK            SDK to use for building: ewdk or wdk, default=ewdk
+    --sign               sign the driver files
+    -p, --package        generate an NSIS installer from the compiled files
+    --cert=CERT          Common name of code signing certificate,
+                         default=openvpn
+    --certfile=CERTFILE  Path to the code signing certificate
+    --certpw=CERTPW      Password for the code signing certificate/key
+                         (optional)
+    --crosscert=CERT     The cross-certificate file to use, default=MSCV-
+                         VSClass3.cer
+    --timestamp=URL      Timestamp URL to use, default=http://timestamp.verisign
+                         .com/scripts/timstamp.dll
+    -a, --oas            Build for OpenVPN Access Server clients
 
 Edit **version.m4** and **paths.py** as necessary then build::
 

--- a/buildtap.py
+++ b/buildtap.py
@@ -73,7 +73,9 @@ class BuildTAPWindows(object):
     # run a command
     def system(self, cmd):
         print "RUN:", cmd
-        os.system(cmd)
+        result = os.system(cmd)
+        if result != 0:
+            raise ValueError("command failed")
 
     # make a directory
     def mkdir(self, dir):

--- a/buildtap.py
+++ b/buildtap.py
@@ -21,9 +21,10 @@ class BuildTAPWindows(object):
             if opt.package:
                 raise ValueError("parameter -p must be used with --ti")
 
-        # path to EWDK
-        self.ewdk_path = paths.EWDK
-        self.ewdk_cmd = os.path.join(self.ewdk_path, "BuildEnv", "SetupBuildEnv.cmd")
+        if opt.sdk == "ewdk":
+            # path to EWDK
+            self.ewdk_path = paths.EWDK
+            self.ewdk_cmd = os.path.join(self.ewdk_path, "BuildEnv", "SetupBuildEnv.cmd")
 
         # path to makensis
         self.makensis = os.path.join(paths.NSIS, 'makensis.exe')
@@ -131,9 +132,15 @@ class BuildTAPWindows(object):
         self.makedirs(dir)
         return dir
 
-    # run an EWDK command
+    # run an (E)WDK command
     def run_ewdk(self, cmd):
-        self.system('cmd /c ""%s" && %s"' % (self.ewdk_cmd, cmd))
+        if opt.sdk == "ewdk":
+            # In EWDK case, run the command after setting the building environment.
+            self.system('cmd /c ""%s" && %s"' % (self.ewdk_cmd, cmd))
+        else:
+            # In WDK case, run the command directly, as the building environment should be set
+            # within Visual Studio Command Prompt already.
+            self.system(cmd)
 
     # parse version.m4 file
     def parse_version_m4(self):
@@ -182,9 +189,9 @@ class BuildTAPWindows(object):
         self.preprocess(kv, os.path.join(self.src, "tap-windows6.vcxproj"))
         self.preprocess(kv, os.path.join(self.src, "config.h"))
 
-    # build a "msbuild" file using EWDK
+    # build a "msbuild" file using (E)WDK
     def build_ewdk(self, project_file, arch):
-        self.run_ewdk('msbuild %s /p:Configuration=%s /p:Platform=%s' % (
+        self.run_ewdk('msbuild.exe %s /p:Configuration=%s /p:Platform=%s' % (
                project_file,
                self.configuration,
                self.architecture_platform_map[arch]
@@ -442,6 +449,7 @@ if __name__ == '__main__':
 
     # defaults
     src = os.path.dirname(os.path.realpath(__file__))
+    sdk = "ewdk"
     cert = "openvpn"
     crosscert = "MSCV-VSClass3.cer" # cross certs available here: http://msdn.microsoft.com/en-us/library/windows/hardware/dn170454(v=vs.85).aspx
     timestamp = "http://timestamp.verisign.com/scripts/timstamp.dll"
@@ -458,6 +466,9 @@ if __name__ == '__main__':
                   help="do an nmake clean before build")
     op.add_option("-b", "--build", action="store_true", dest="build",
                   help="build TAP-Windows and possibly tapinstall (add -c to clean before build)")
+    op.add_option("--sdk", dest="sdk", metavar="SDK",
+                  default=sdk,
+                  help="SDK to use for building: ewdk or wdk, default=%s" % (sdk,))
     op.add_option("--sign", action="store_true", dest="codesign",
                   default=False, help="sign the driver files")
     op.add_option("-p", "--package", action="store_true", dest="package",


### PR DESCRIPTION
This set of patches reestablishes the AppVeyor building.

AppVeyor has no EWDK, therefore the `buildtap.py` was updated to support Visual Studio 2015 and Windows Driver Kit 10 building.

Furthermore, the `buildtap.py` now checks for an error return status of invoked commands to stop on build errors.