### PR TITLE
Remove overly strict buffer length check

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -351,12 +351,6 @@ Return Value:
     inBufLength = irpSp->Parameters.DeviceIoControl.InputBufferLength;
     outBufLength = irpSp->Parameters.DeviceIoControl.OutputBufferLength;
 
-    if (!inBufLength || !outBufLength)
-    {
-        ntStatus = STATUS_INVALID_PARAMETER;
-        goto End;
-    }
-
     //
     // Determine which I/O control code was specified.
     //


### PR DESCRIPTION
This file contains a check that required both input and output buffers to have nonzero size when processing DeviceIoControl commands.  This is too strict, since most commands require only input _or_ output, not both.  It's duplicative, because each command-handling block still has to check whether the relevant buffer is the right size.  It violates [the API definition](https://docs.microsoft.com/en-us/windows/desktop/api/ioapiset/nf-ioapiset-deviceiocontrol), e.g.
```
lpInBuffer
...
This parameter can be NULL if dwIoControlCode specifies an operation that does not require input data.
```
Most importantly, it has caused problems for a number of developers:
https://github.com/ambrop72/badvpn/issues/2
https://github.com/ambrop72/badvpn/issues/16