### PR TITLE
hlk3: Pad received packets to minimum ethernet length

### DIFF
--- a/src/adapter.h
+++ b/src/adapter.h
@@ -161,6 +161,11 @@ typedef struct _TAP_ADAPTER_CONTEXT
     // waiting to be read by user-mode application.
     TAP_PACKET_QUEUE            SendPacketQueue;
 
+    // Transmit flow control
+    KSPIN_LOCK                  FlowControlLock;
+    PNET_BUFFER_LIST            FlowControlList;
+    BOOLEAN                     FlowControlHasPackets;
+
     // NBL pool for making TAP receive indications.
     NDIS_HANDLE                 ReceiveNblPool;
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -90,7 +90,9 @@
 #define TAP_MAX_MCAST_LIST                 32
 
 #define TAP_MAX_LOOKAHEAD                  TAP_FRAME_MAX_DATA_SIZE
-#define TAP_BUFFER_SIZE                    TAP_MAX_FRAME_SIZE
+
+// Simulated send/receive buffer size for the virtual device.
+#define TAP_BUFFER_SIZE                    0x400000
 
 // Set this value to TRUE if there is a physical adapter.
 #define TAP_HAS_PHYSICAL_CONNECTOR         FALSE

--- a/src/mem.c
+++ b/src/mem.c
@@ -105,6 +105,8 @@ tapPacketQueueInsertTail(
 
     // Update counts
     ++TapPacketQueue->Count;
+    TapPacketQueue->TotalBytes += (TapPacket->m_SizeFlags & TP_SIZE_MASK);
+
 
     if(TapPacketQueue->Count > TapPacketQueue->MaxCount)
     {
@@ -134,6 +136,7 @@ tapPacketRemoveHeadLocked(
 
         // Update counts
         --TapPacketQueue->Count;
+        TapPacketQueue->TotalBytes -= (tapPacket->m_SizeFlags & TP_SIZE_MASK);
     }
 
     return tapPacket;

--- a/src/mem.h
+++ b/src/mem.h
@@ -62,7 +62,8 @@ typedef struct _TAP_PACKET_QUEUE
 {
     KSPIN_LOCK      QueueLock;
     LIST_ENTRY      Queue;
-    ULONG           Count;   // Count of currently queued items
+    ULONG           Count;          // Count of currently queued items
+    ULONG           TotalBytes;     // Total length of queued packets
     ULONG           MaxCount;
 } TAP_PACKET_QUEUE, *PTAP_PACKET_QUEUE;
 

--- a/src/oidrequest.c
+++ b/src/oidrequest.c
@@ -646,6 +646,44 @@ Return Value:
         ulInfo = (ULONG) TAP_MAX_FRAME_SIZE;
         pInfo = &ulInfo;
         break;
+    
+    case OID_GEN_TRANSMIT_BUFFER_SPACE:
+        //
+        // The OID_GEN_TRANSMIT_BUFFER_SPACE OID specifies the amount of
+        // memory, in bytes, on the NIC that is available for buffering
+        // transmit data. This should exclude space that is already used
+        // by the queued data.
+        //
+
+        ulInfo = (ULONG) TAP_BUFFER_SIZE;
+        pInfo = &ulInfo;
+        break;
+
+    case OID_GEN_RECEIVE_BUFFER_SPACE:
+        //
+        // The OID_GEN_RECEIVE_BUFFER_SPACE OID specifies the amount of
+        // memory on the NIC that is available for buffering receive data. 
+        // This should exclude space used by queued data.
+        //
+        
+        ulInfo = (ULONG) TAP_BUFFER_SIZE;
+        pInfo = &ulInfo;
+        break;
+
+    case OID_GEN_MAXIMUM_SEND_PACKETS:
+        //
+        // The OID_GEN_MAXIMUM_SEND_PACKETS OID specifies the maximum 
+        // number of send packet descriptors that a miniport driver's 
+        // MiniportSendPackets function can accept.
+        // This OID is still marked as mandatory in the HLK tests, but
+        // documentation states it is obsolete in NDIS 6+
+        // In this case, a large arbitrary value is used because this
+        // driver has no real limit.
+        //
+
+        ulInfo = (ULONG) 5000;
+        pInfo = &ulInfo;
+        break;
 
     case OID_GEN_INTERRUPT_MODERATION:
         if (OidRequest->DATA.QUERY_INFORMATION.InformationBufferLength < sizeof(NDIS_INTERRUPT_MODERATION_PARAMETERS))
@@ -940,8 +978,6 @@ Return Value:
         break;
 
         // TODO: Inplement these query information requests.
-    case OID_GEN_RECEIVE_BUFFER_SPACE:
-    case OID_GEN_MAXIMUM_SEND_PACKETS:
     case OID_GEN_TRANSMIT_QUEUE_LENGTH:
     case OID_802_3_XMIT_HEARTBEAT_FAILURE:
     case OID_802_3_XMIT_TIMES_CRS_LOST:

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -58,6 +58,16 @@ tapFlushSendPacketQueue(
     );
 
 VOID
+tapCompleteFlowControlPackets(
+    __in PTAP_ADAPTER_CONTEXT   Adapter
+    );
+
+VOID
+tapCheckFlowControl(
+    __in PTAP_ADAPTER_CONTEXT   Adapter
+    );
+
+VOID
 IndicateReceivePacket(
     __in PTAP_ADAPTER_CONTEXT  Adapter,
     __in PUCHAR packetData,


### PR DESCRIPTION
HLK tests require that packets are padded to the minimum ethernet length. While that isn't strictly necessary for something like tap-windows6, it has been implemented here to make the test happy.
The change adds padding to the packet to be returned to the OS if necessary to meet this requirement, combining this padding with prefixing if possible (on the TUN path)