### PR TITLE
hlk5: Implement receive packet filtering

### DIFF
--- a/src/adapter.h
+++ b/src/adapter.h
@@ -326,6 +326,12 @@ tapAdapterSendAndReceiveReady(
     );
 
 ULONG
+tapGetRawPacketFrameType(
+    __in PTAP_ADAPTER_CONTEXT    Adapter,
+    __in PVOID                   PacketBuffer
+    );
+
+ULONG
 tapGetNetBufferFrameType(
     __in PNET_BUFFER       NetBuffer
     );


### PR DESCRIPTION
HLK tests require that the adapter supports basic packet filtering, based on a set of packet class bits provided to the adapter. This change implements that filtering