### PR TITLE
hlk7: Add TapDiag interface to support testing

### DIFF
--- a/src/adapter.h
+++ b/src/adapter.h
@@ -29,7 +29,8 @@
 #define TAP_RX_NBL_TAG              ((ULONG)'RpaT')     // "TapR
 #define TAP_RX_INJECT_BUFFER_TAG    ((ULONG)'IpaT')     // "TapI
 
-#define TAP_MAX_NDIS_NAME_LENGTH     64     // 38 character GUID string plus extra..
+#define TAP_MAX_NDIS_NAME_LENGTH        64     // 38 character GUID string plus extra..
+#define TAP_MAX_NDIS_DIAG_NAME_LENGTH   96     // Diag name is a little longer
 
 // TAP receive indication NBL flag definitions.
 #define TAP_RX_NBL_FLAGS                    NBL_FLAGS_MINIPORT_RESERVED
@@ -158,6 +159,15 @@ typedef struct _TAP_ADAPTER_CONTEXT
     PFILE_OBJECT                TapFileObject;      // Exclusive access
     BOOLEAN                     TapFileIsOpen;      // WAS: m_TapOpens
     LONG                        TapFileOpenCount;   // WAS: m_NumTapOpens
+
+    NDIS_STRING                 DiagDeviceName;
+    WCHAR                       DiagDeviceNameBuffer[TAP_MAX_NDIS_DIAG_NAME_LENGTH];
+
+    NDIS_STRING                 DiagLinkName;
+    WCHAR                       DiagLinkNameBuffer[TAP_MAX_NDIS_DIAG_NAME_LENGTH];
+
+    NDIS_HANDLE                 DiagDeviceHandle;
+    PDEVICE_OBJECT              DiagDeviceObject;
 
     // Cancel-Safe read IRP queue.
     TAP_IRP_CSQ                 PendingReadIrpQueue;

--- a/src/tap.h
+++ b/src/tap.h
@@ -78,6 +78,8 @@ typedef struct _TAP_GLOBAL
 
     BOOLEAN             RunningWindows8OrGreater;
 
+    BOOLEAN             EnableTapDiag;
+
 } TAP_GLOBAL, *PTAP_GLOBAL;
 
 


### PR DESCRIPTION
HLK tests require two things that are not supported in OpenVPN currently.

1. 2c_Priority test requires the priority feature to be enabled (no priority tagging is sent by default)
2. LinkCheck test requires that the ethernet cable be removed and reattached

To support these, when enabled by a registry key, a "TapDiag" device is created alongside the "Tap" device.
This can be opened while OpenVPN is using the main tap device, and allows a side application to reach in and send some specific IOCTLs to modify the device state.

A hacky side tool has been written to serve these purposes and is available here https://github.com/sgstair/tapdiag