### PR TITLE
Add support for version.m4 overrides

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,8 @@ View build script options::
                          VSClass3.cer
     --timestamp=URL      Timestamp URL to use, default=http://timestamp.verisign
                          .com/scripts/timstamp.dll
-    -a, --oas            Build for OpenVPN Access Server clients
+    --versionoverride=FILE
+                         Path to the version override file
 
 Edit **version.m4** and **paths.py** as necessary then build::
 
@@ -175,6 +176,16 @@ directory.
 
 For more detailed instructions and background information please refer to
 `this article <https://community.openvpn.net/openvpn/wiki/BuildingTapWindows6>`_ on OpenVPN community wiki.
+
+Overriding setting defined in version.m4
+----------------------------------------
+
+It is possible to override one or more of the settings in version.m4 file with
+the --versionoverride <file> option. Any settings given in the override file
+have precedence over those in version.m4.
+
+This is useful when building several tap-windows6 drivers with different
+component ids for example.
 
 Notes on proxies
 ----------------

--- a/sign/Create-DriverSubmission.ps1
+++ b/sign/Create-DriverSubmission.ps1
@@ -1,7 +1,8 @@
 # Produce Windows 10 DDF cabined files for attestation signing
 Param (
     [string]$DistDir = "${PSScriptRoot}\..\dist",
-    [String]$DDFTemplate = "${PSScriptRoot}\tap-windows6.ddf"
+    [String]$DDFTemplate = "${PSScriptRoot}\tap-windows6.ddf",
+    [String]$CabinetBaseName = "tap-windows6"
 )
 
 . "${PSScriptRoot}\Verify-Path.ps1"
@@ -11,9 +12,9 @@ Verify-Path $DDFTemplate "tap-windows6 DDF template"
 Verify-Path $DistDir "tap-windows6 dist directory"
 
 foreach ($arch in "i386", "amd64", "arm64") {
-    $ddf_file = "tap-windows6-${arch}.ddf"
+    $ddf_file = "${CabinetBaseName}-${arch}.ddf"
     # makecab.exe can only understand Ascii files
-    (Get-Content $DDFTemplate) -replace ("%ARCH%", "$arch")|Out-File $ddf_File -Encoding Ascii
+    (Get-Content $DDFTemplate) -replace ("%ARCH%", "$arch") -replace ("%CABINETBASENAME%", "$CabinetBaseName")|Out-File $ddf_file -Encoding Ascii
     (Get-ChildItem "${DistDir}\${arch}").FullName|Out-File $ddf_file -Append -Encoding Ascii
     & makecab.exe /F "${ddf_file}"
     "${PSScriptRoot}/Sign-File.ps1 ${ddf_file}"

--- a/sign/tap-windows6.ddf
+++ b/sign/tap-windows6.ddf
@@ -11,6 +11,6 @@
 .Set Cabinet=on
 .Set Compress=on
 ;Specify file name for new cab file
-.Set CabinetNameTemplate=tap-windows6-%ARCH%.cab
+.Set CabinetNameTemplate=%CABINETBASENAME%-%ARCH%.cab
 ;Specify files to be included in cab file
 .Set DestinationDir=%ARCH%


### PR DESCRIPTION
This is useful when building multiple versions of the same driver
with different component ids, descriptions and such.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>