### PR TITLE
Introduce TAP adapter as a virtual device

### DIFF
--- a/src/OemVista.inf.in
+++ b/src/OemVista.inf.in
@@ -91,7 +91,7 @@
    Characteristics = @PRODUCT_TAP_WIN_CHARACTERISTICS@
    *IfType            = 0x6 ; IF_TYPE_ETHERNET_CSMACD
    *MediaType         = 0x0 ; NdisMedium802_3
-   *PhysicalMediaType = 14  ; NdisPhysicalMedium802_3
+   *PhysicalMediaType = 0   ; NdisPhysicalMediumUnspecified
 
 [@PRODUCT_TAP_WIN_COMPONENT_ID@.ndi.Services]
    AddService = @PRODUCT_TAP_WIN_COMPONENT_ID@,        2, @PRODUCT_TAP_WIN_COMPONENT_ID@.service

--- a/src/OemVista.inf.in
+++ b/src/OemVista.inf.in
@@ -89,7 +89,7 @@
    AddReg          = @PRODUCT_TAP_WIN_COMPONENT_ID@.reg
    AddReg          = @PRODUCT_TAP_WIN_COMPONENT_ID@.params.reg
    Characteristics = @PRODUCT_TAP_WIN_CHARACTERISTICS@
-   *IfType            = 0x6 ; IF_TYPE_ETHERNET_CSMACD
+   *IfType            = 53  ; IF_TYPE_PROP_VIRTUAL
    *MediaType         = 0x0 ; NdisMedium802_3
    *PhysicalMediaType = 0   ; NdisPhysicalMediumUnspecified
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -101,7 +101,7 @@
 #define TAP_CONNECTION_TYPE                NET_IF_CONNECTION_DEDICATED
 
 // This value must match the *IfType in the driver .inf file
-#define TAP_IFTYPE                         IF_TYPE_ETHERNET_CSMACD
+#define TAP_IFTYPE                         IF_TYPE_PROP_VIRTUAL
 
 //
 // This is a virtual device, so it can tolerate surprise removal and


### PR DESCRIPTION
One thing that I've had on the back of my mind for a while (but never got time to test it) was `*IfType` and `*PhysicalMediaType` settings in tap-windows6... Has anybody tried to change `*IfType` from `IF_TYPE_ETHERNET_CSMACD` to `IF_TYPE_PROP_VIRTUAL` and `*PhysicalMediaType` from `NdisPhysicalMedium802_3` to `NdisPhysicalMediumUnspecified` yet? This would stop advertising tap-windows6 device as a physical Ethernet card, but a virtual device. Leaving `*MediaType` set to `NdisMedium802_3`, a virtual layer 2 device actually - namely a TAP device.

IMHO, this might solve a couple of things:
- HP Envy notebooks switching WiFi off when OpenVPN connection is established issue
- Simplify HLK tests:
   - tap-windows6 is no longer a physical NIC and should no longer require physical hardware to test on
   - Will tap-windows6 still require "Network.Ethernet.*" tests to be performed at all?