### PR TITLE
buildtap.py: Fix --clean when no --ti specified

### DIFF
--- a/buildtap.py
+++ b/buildtap.py
@@ -21,6 +21,7 @@ class BuildTAPWindows(object):
             self.using_prebuilt_tapinstall = not os.path.isfile(devcon_project_file)
         else:
             self.top_tapinstall = None
+            self.using_prebuilt_tapinstall = True
             if opt.package:
                 raise ValueError("parameter -p must be used with --ti")
 


### PR DESCRIPTION
When tapinstall source directory is not specified, the `using_prebuilt_tapinstall` member of `BuildTAPWindows` class was not
defined making `--clean` to fail.