### PR TITLE
Fix the name of the registry parameter for MAC address

### DIFF
--- a/src/OemVista.inf.in
+++ b/src/OemVista.inf.in
@@ -88,6 +88,7 @@
    CopyFiles       = @PRODUCT_TAP_WIN_COMPONENT_ID@.driver, @PRODUCT_TAP_WIN_COMPONENT_ID@.files
    AddReg          = @PRODUCT_TAP_WIN_COMPONENT_ID@.reg
    AddReg          = @PRODUCT_TAP_WIN_COMPONENT_ID@.params.reg
+   DelReg          = @PRODUCT_TAP_WIN_COMPONENT_ID@.params.delreg
    Characteristics = @PRODUCT_TAP_WIN_CHARACTERISTICS@
    *IfType            = 53  ; IF_TYPE_PROP_VIRTUAL
    *MediaType         = 0x0 ; NdisMedium802_3
@@ -117,15 +118,18 @@
    HKR, Ndi\params\MediaStatus,          Optional,  0, "0"
    HKR, Ndi\params\MediaStatus\enum,     "0",       0, "Application Controlled"
    HKR, Ndi\params\MediaStatus\enum,     "1",       0, "Always Connected"
-   HKR, Ndi\params\MAC,                  ParamDesc, 0, "MAC Address"
-   HKR, Ndi\params\MAC,                  Type,      0, "edit"
-   HKR, Ndi\params\MAC,                  Optional,  0, "1"
+   HKR, Ndi\params\NetworkAddress,       ParamDesc, 0, "MAC Address"
+   HKR, Ndi\params\NetworkAddress,       Type,      0, "edit"
+   HKR, Ndi\params\NetworkAddress,       Optional,  0, "1"
    HKR, Ndi\params\AllowNonAdmin,        ParamDesc, 0, "Non-Admin Access"
    HKR, Ndi\params\AllowNonAdmin,        Type,      0, "enum"
    HKR, Ndi\params\AllowNonAdmin,        Default,   0, "1"
    HKR, Ndi\params\AllowNonAdmin,        Optional,  0, "0"
    HKR, Ndi\params\AllowNonAdmin\enum,   "0",       0, "Not Allowed"
    HKR, Ndi\params\AllowNonAdmin\enum,   "1",       0, "Allowed"
+
+[@PRODUCT_TAP_WIN_COMPONENT_ID@.params.delreg]
+   HKR, Ndi\params\MAC
 
 ;----------------------------------------------------------------
 ;                             Service Section


### PR DESCRIPTION
- Replace registry entry MAC by NetworkAddress.
- Add a directive to remove any old entry named MAC
  to support upgrade.

No validation of input is done. Windows accepts MAC
as 12 hex characters with an optional hyphen between
bytes but not colons. Also the MAC should be a valid
"locally administered address".

See also issue #97 

Signed-off-by: Selva Nair <selva.nair@gmail.com>