### PR TITLE
Use CurrentAddress for MAC instead of PermanentAddress

### DIFF
--- a/src/adapter.h
+++ b/src/adapter.h
@@ -142,8 +142,8 @@ typedef struct _TAP_ADAPTER_CONTEXT
 
     BOOLEAN                     AllowNonAdmin;
 
-    MACADDR                     PermanentAddress;   // From registry, if available
-    MACADDR                     CurrentAddress;
+    MACADDR                     PermanentAddress;   // Generated from adapter GUID
+    MACADDR                     CurrentAddress;     // From registry or same as above
 
     // Device registration parameters from NdisRegisterDeviceEx.
     NDIS_STRING                 DeviceName;

--- a/src/txpath.c
+++ b/src/txpath.c
@@ -156,7 +156,7 @@ HandleIPv6NeighborDiscovery(
 
     // ethernet header
     na->eth.proto = htons(NDIS_ETH_TYPE_IPV6);
-    ETH_COPY_NETWORK_ADDRESS(na->eth.dest, Adapter->PermanentAddress);
+    ETH_COPY_NETWORK_ADDRESS(na->eth.dest, Adapter->CurrentAddress);
     ETH_COPY_NETWORK_ADDRESS(na->eth.src, Adapter->m_TapToUser.dest);
 
     // IPv6 header
@@ -225,8 +225,8 @@ ProcessARP(
     // Is this the kind of packet we are looking for?
     //-----------------------------------------------
     if (src->m_Proto == htons (NDIS_ETH_TYPE_ARP)
-        && MAC_EQUAL (src->m_MAC_Source, Adapter->PermanentAddress)
-        && MAC_EQUAL (src->m_ARP_MAC_Source, Adapter->PermanentAddress)
+        && MAC_EQUAL (src->m_MAC_Source, Adapter->CurrentAddress)
+        && MAC_EQUAL (src->m_ARP_MAC_Source, Adapter->CurrentAddress)
         && ETH_IS_BROADCAST(src->m_MAC_Destination)
         && src->m_ARP_Operation == htons (ARP_REQUEST)
         && src->m_MAC_AddressType == htons (MAC_ADDR_TYPE)
@@ -254,9 +254,9 @@ ProcessARP(
             // ARP addresses
             //----------------------------------------------      
             ETH_COPY_NETWORK_ADDRESS (arp->m_MAC_Source, mac);
-            ETH_COPY_NETWORK_ADDRESS (arp->m_MAC_Destination, Adapter->PermanentAddress);
+            ETH_COPY_NETWORK_ADDRESS (arp->m_MAC_Destination, Adapter->CurrentAddress);
             ETH_COPY_NETWORK_ADDRESS (arp->m_ARP_MAC_Source, mac);
-            ETH_COPY_NETWORK_ADDRESS (arp->m_ARP_MAC_Destination, Adapter->PermanentAddress);
+            ETH_COPY_NETWORK_ADDRESS (arp->m_ARP_MAC_Destination, Adapter->CurrentAddress);
             arp->m_ARP_IP_Source = src->m_ARP_IP_Destination;
             arp->m_ARP_IP_Destination = adapter_ip;
 


### PR DESCRIPTION
While checking packets for proxy arp etc., use of either the
current or permanent address worked in the past when we used
to overwrite the PermanentAddress with the user-defined value
(if any). Since commit f4f6464cac we directly set the
CurrentAddress to the customized value and leave the
PermanentAddress unchanged.

The DHCP code is unchanged as it already uses the CurrentAddress.

Also update the description of these fields in comments to better
match the code.

Signed-off-by: Selva Nair <selva.nair@gmail.com>

Unlike ARP, NA works even without this change to my surprise. Probably
because its only the destination MAC that is wrong in the response,
the IP is correct. Looks like magic to me.