### PR TITLE
fix bug: Only send packet when packetlength>=Etherheader(14)+IPv4header(20), but some Ether Packets have no IP header

### DIFF
--- a/src/txpath.c
+++ b/src/txpath.c
@@ -902,10 +902,10 @@ Return Value:
 
             packetLength = NET_BUFFER_DATA_LENGTH(currentNb);
 
-            // Minimum packet size is size of Ethernet plus IPv4 headers.
-            ASSERT(packetLength >= (ETHERNET_HEADER_SIZE + IP_HEADER_SIZE));
+            // Minimum packet size is size of Ethernet.
+            ASSERT(packetLength >= ETHERNET_HEADER_SIZE);
 
-            if(packetLength < (ETHERNET_HEADER_SIZE + IP_HEADER_SIZE))
+            if(packetLength < ETHERNET_HEADER_SIZE)
             {
                 return FALSE;
             }


### PR DESCRIPTION
fix bug: Only send packet when packetlength>=Etherheader(14)+IPv4header(20), but some Ether Packets have no IP header

See issues: #158 