### PR TITLE
Allowing to use the configured MTU and to work with HPE Aruba Client

### DIFF
--- a/COPYRIGHT.GPL
+++ b/COPYRIGHT.GPL
@@ -338,4 +338,4 @@ consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
 
-Copyright (C) 2022 Hewlett Packard Enterprise Development LP
+Copyright 2022 Hewlett Packard Enterprise Development LP

--- a/COPYRIGHT.GPL
+++ b/COPYRIGHT.GPL
@@ -337,3 +337,5 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
+
+Copyright (C) 2022 Hewlett Packard Enterprise Development LP

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -722,7 +722,7 @@ AdapterCreate(
         // Specifiy the maximum network frame size, in bytes, that the NIC
         // supports excluding the header.
         //
-        genAttributes.MtuSize = TAP_FRAME_MAX_DATA_SIZE;
+        genAttributes.MtuSize = adapter->MtuSize;
         genAttributes.MaxXmitLinkSpeed = TAP_XMIT_SPEED;
         genAttributes.XmitLinkSpeed = TAP_XMIT_SPEED;
         genAttributes.MaxRcvLinkSpeed = TAP_RECV_SPEED;

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -21,7 +21,7 @@
  *  distribution); if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- *  Copyright (C) 2022 Hewlett Packard Enterprise Development LP
+ *  Copyright 2022 Hewlett Packard Enterprise Development LP
  */
 #ifndef __TAP_ADAPTER_CONTEXT_H_
 #define __TAP_ADAPTER_CONTEXT_H_

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -20,6 +20,8 @@
  *  along with this program (see the file COPYING included with this
  *  distribution); if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  Copyright (C) 2022 Hewlett Packard Enterprise Development LP
  */
 #ifndef __TAP_ADAPTER_CONTEXT_H_
 #define __TAP_ADAPTER_CONTEXT_H_
@@ -272,6 +274,12 @@ typedef struct _TAP_ADAPTER_CONTEXT
   // resources.
   BOOLEAN m_CalledAdapterFreeResources;
   BOOLEAN m_RegisteredAdapterShutdownHandler;
+
+
+#ifdef ARUBA_SPECIFIC
+  // Handle Aruba specific logic
+  BOOLEAN m_IsLoadedByAruba;
+#endif
 
 } TAP_ADAPTER_CONTEXT, *PTAP_ADAPTER_CONTEXT;
 

--- a/src/device.c
+++ b/src/device.c
@@ -21,7 +21,7 @@
  *  distribution); if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- *  Copyright (C) 2022 Hewlett Packard Enterprise Development LP
+ *  Copyright 2022 Hewlett Packard Enterprise Development LP
  */
 
 //

--- a/src/device.c
+++ b/src/device.c
@@ -20,6 +20,8 @@
  *  along with this program (see the file COPYING included with this
  *  distribution); if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  Copyright (C) 2022 Hewlett Packard Enterprise Development LP
  */
 
 //
@@ -703,7 +705,11 @@ Return Value:
             Irp->IoStatus.Status = ntStatus = STATUS_INVALID_PARAMETER;
         }
         break;
-
+#ifdef ARUBA_SPECIFIC
+    case TAP_WIN_IOCTL_CONFIG_LOADER_FLAG:
+        adapter->m_IsLoadedByAruba = TRUE;
+        break;
+#endif
     default:
 
         //

--- a/src/resource.rc
+++ b/src/resource.rc
@@ -36,11 +36,11 @@
 				VFT2_DRV_COMM
 */
 
-#define VER_COMPANYNAME_STR         "The OpenVPN Project"
-#define VER_FILEDESCRIPTION_STR     "TAP-Windows Virtual Network Driver (NDIS 6.0)"
+#define VER_COMPANYNAME_STR         "Hewlett Packard Enterprise"
+#define VER_FILEDESCRIPTION_STR     "Aruba Networks Virtual Adapter"
 #define VER_ORIGINALFILENAME_STR    PRODUCT_TAP_WIN_COMPONENT_ID ".sys"
 #define VER_LEGALCOPYRIGHT_YEARS    "2003-2018"
-#define VER_LEGALCOPYRIGHT_STR      "OpenVPN Technologies, Inc."
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2022 Hewlett Packard Enterprise Development LP."
 
 
 #define VER_PRODUCTNAME_STR         VER_FILEDESCRIPTION_STR

--- a/src/resource.rc
+++ b/src/resource.rc
@@ -40,7 +40,7 @@
 #define VER_FILEDESCRIPTION_STR     "Aruba Networks Virtual Adapter"
 #define VER_ORIGINALFILENAME_STR    PRODUCT_TAP_WIN_COMPONENT_ID ".sys"
 #define VER_LEGALCOPYRIGHT_YEARS    "2003-2018"
-#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2022 Hewlett Packard Enterprise Development LP."
+#define VER_LEGALCOPYRIGHT_STR      "Copyright 2022 Hewlett Packard Enterprise Development LP."
 
 
 #define VER_PRODUCTNAME_STR         VER_FILEDESCRIPTION_STR

--- a/src/tap-windows.h
+++ b/src/tap-windows.h
@@ -21,6 +21,8 @@
  *  along with this program (see the file COPYING included with this
  *  distribution); if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  Copyright 2022 Hewlett Packard Enterprise Development LP
  */
 #ifndef __TAP_WIN_H
 #define __TAP_WIN_H

--- a/src/tap-windows.h
+++ b/src/tap-windows.h
@@ -53,6 +53,9 @@
 
 /* Control whether 802.1Q headers are added for priority */
 #define TAP_WIN_IOCTL_PRIORITY_BEHAVIOR     TAP_WIN_CONTROL_CODE (11, METHOD_BUFFERED)
+#ifdef ARUBA_SPECIFIC
+#define TAP_WIN_IOCTL_CONFIG_LOADER_FLAG	TAP_WIN_CONTROL_CODE (12, METHOD_BUFFERED)
+#endif
 #define TAP_PRIORITY_BEHAVIOR_NOPRIORITY    0
 #define TAP_PRIORITY_BEHAVIOR_ENABLED       1
 #define TAP_PRIORITY_BEHAVIOR_ADDALWAYS     2
@@ -77,6 +80,6 @@
 #define USERMODEDEVICEDIR "\\\\.\\Global\\"
 #define SYSDEVICEDIR      "\\Device\\"
 #define USERDEVICEDIR     "\\DosDevices\\Global\\"
-#define TAP_WIN_SUFFIX    ".tap"
+#define TAP_WIN_SUFFIX    ".avnic"
 
 #endif // __TAP_WIN_H

--- a/src/txpath.c
+++ b/src/txpath.c
@@ -20,6 +20,8 @@
  *  along with this program (see the file COPYING included with this
  *  distribution); if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *  Copyright (C) 2022 Hewlett Packard Enterprise Development LP
  */
 
 //
@@ -221,6 +223,21 @@ ProcessARP(
     __in const MACADDR mac
     )
 {
+
+#ifdef ARUBA_SPECIFIC
+    BOOLEAN bIsDestinationSame = FALSE;
+
+    if (TRUE == Adapter->m_IsLoadedByAruba)
+    {
+        bIsDestinationSame = TRUE;
+    }
+    else
+    {
+        bIsDestinationSame = (src->m_ARP_IP_Destination & ip_netmask) == ip_network ? TRUE : FALSE;
+    }
+#endif //ARUBA_SPECIFIC
+
+
     //-----------------------------------------------
     // Is this the kind of packet we are looking for?
     //-----------------------------------------------
@@ -234,7 +251,11 @@ ProcessARP(
         && src->m_PROTO_AddressType == htons (NDIS_ETH_TYPE_IPV4)
         && src->m_PROTO_AddressSize == sizeof (IPADDR)
         && src->m_ARP_IP_Source == adapter_ip
+#ifndef ARUBA_SPECIFIC
         && (src->m_ARP_IP_Destination & ip_netmask) == ip_network
+#else
+        && bIsDestinationSame
+#endif
         && src->m_ARP_IP_Destination != adapter_ip)
     {
         ARP_PACKET *arp = (ARP_PACKET *) MemAlloc (sizeof (ARP_PACKET), TRUE);

--- a/src/txpath.c
+++ b/src/txpath.c
@@ -21,7 +21,7 @@
  *  distribution); if not, write to the Free Software Foundation, Inc.,
  *  59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  *
- *  Copyright (C) 2022 Hewlett Packard Enterprise Development LP
+ *  Copyright 2022 Hewlett Packard Enterprise Development LP
  */
 
 //


### PR DESCRIPTION
1. Modified code to use the configured MTU.
2. Setting `bIsDestinationSame` to TRUE to work with HPE Aruba Client.
3. Added the conditional logic to `bIsDestinationSame` based on which client it is loaded by. 
4. `bIsDestinationSame` related changes are conditionally compiled based on the macro `ARUBA_SPECIFIC` value.